### PR TITLE
修改mybaits的paramsHandler赋值逻辑

### DIFF
--- a/sqlhelper-mybatis/src/main/java/com/jn/sqlhelper/mybatis/plugins/CustomMybatisParameterHandler.java
+++ b/sqlhelper-mybatis/src/main/java/com/jn/sqlhelper/mybatis/plugins/CustomMybatisParameterHandler.java
@@ -38,6 +38,7 @@ public class CustomMybatisParameterHandler implements ParameterHandler, PagedPre
 
     protected final TypeHandlerRegistry typeHandlerRegistry;
     protected final MappedStatement mappedStatement;
+    //次此参数在mybaits传递过来的时候一般是map.
     protected Object parameterObject;
     protected final BoundSql boundSql;
     protected final Configuration configuration;
@@ -110,7 +111,7 @@ public class CustomMybatisParameterHandler implements ParameterHandler, PagedPre
         return this.boundSql.getParameterMappings().size();
     }
 
-    private Object getUniqueParameterObject(){
+    protected Object getUniqueParameterObject(){
         if(this.parameterObject==null){
             return this.getParameterObject();
         }

--- a/sqlhelper-mybatisplus/src/main/java/com/jn/sqlhelper/mybatisplus/plugins/pagination/CustomMybatisPlusParameterHandler.java
+++ b/sqlhelper-mybatisplus/src/main/java/com/jn/sqlhelper/mybatisplus/plugins/pagination/CustomMybatisPlusParameterHandler.java
@@ -55,7 +55,8 @@ public class CustomMybatisPlusParameterHandler extends CustomMybatisParameterHan
     /*
      * 此逻辑自定义全局参数填充器 mybatis-plus的逻辑自定义完以后会修改父类的parameterObject.故必须重写setParameters中获取parameterObject方法
      * e.g.
-     *  如果每个表都有类似创建.就可以使用此逻辑
+     *  如果每个表都有一些公共字段创建.就可以使用此逻辑
+     *  实现MetaObjectHandler 接口即可
      */
     public static Object processBatch(MappedStatement ms, Object parameterObject) {
         if (null != parameterObject && !Primitives.isPrimitiveOrPrimitiveWrapperType(parameterObject.getClass()) && parameterObject.getClass() != String.class) {
@@ -119,7 +120,7 @@ public class CustomMybatisPlusParameterHandler extends CustomMybatisParameterHan
             return null;
         }
     }
-    
+
     public static Collection<Object> getParameters(Object parameter) {
         Collection<Object> parameters = null;
         if (parameter instanceof Collection) {
@@ -138,8 +139,7 @@ public class CustomMybatisPlusParameterHandler extends CustomMybatisParameterHan
         return (Collection) parameters;
     }
 
-    public static Object populateKeys(MetaObjectHandler metaObjectHandler, TableInfo tableInfo, MappedStatement
-            ms, Object parameterObject, boolean isInsert) {
+    public static Object populateKeys(MetaObjectHandler metaObjectHandler, TableInfo tableInfo, MappedStatement ms, Object parameterObject, boolean isInsert) {
         if (null == tableInfo) {
             return parameterObject;
         } else {


### PR DESCRIPTION
由于在子类传给父类时。本身的参数已经发生了改变。故必须重写setParameters中获取parameterObject方法。